### PR TITLE
Git Integration: Add 25.0 support and remove noisy logging

### DIFF
--- a/workspace_diff.sh
+++ b/workspace_diff.sh
@@ -3,6 +3,8 @@
 
 echo "Comparing changes on '" $1 "' using FME Workspace Compare"
 
-fmeworkbench -TITLE-OVERRIDE "[$1] Compare Changes" -COMPARE-TITLE1 "Left" -COMPARE-TITLE2 "Right" -COMPARE $5 $2
+fmeworkbench -TITLE-OVERRIDE "[$1] Compare Changes" \
+   -COMPARE-TITLE1 "Left" -COMPARE-TITLE2 "Right" \
+   -COMPARE $5 $2
 
 exit 0

--- a/workspace_diff.sh
+++ b/workspace_diff.sh
@@ -3,6 +3,9 @@
 
 echo "Comparing changes on '" $1 "' using FME Workspace Compare"
 
+# Surpress Qt log messages to avoid adding noise in users workflow
+export QT_LOGGING_RULES="*=false"
+
 fmeworkbench -TITLE-OVERRIDE "[$1] Compare Changes" \
    -COMPARE-TITLE1 "Left" -COMPARE-TITLE2 "Right" \
    -COMPARE $5 $2

--- a/workspace_merge.sh
+++ b/workspace_merge.sh
@@ -2,4 +2,37 @@
 # Arguments are: ancestor-file current-file other-file path
 echo "Launching FMEWorkbench to merge " $4 
 
-fmeworkbench -TITLE-OVERRIDE "[$4] Merge" -COMPARE-BASE $1 -COMPARE-BASE-TITLE "Base" -COMPARE-TITLE1 "Ours" -COMPARE-TITLE2 "Theirs" -COMPARE $2 $3
+# As of FME 2025.0, workspace comparison MUST be done on files that end either in .fmx or .fmw. 
+# The temporary files that git creates are in either of these extensions, so we need to create 
+# our own temporary files that have the proper extension depending on if the file we're attempting 
+# to resolve merge conflcits for is .fmx or .fmw. Then after we use finish our merge we copy the 
+# content back into the temporary files git is expecting to be updated
+extension=".${4##*.}"
+
+ancestor_temp=$(mktemp --suffix="$extension")
+current_temp=$(mktemp --suffix="$extension")
+other_temp=$(mktemp --suffix="$extension")
+result_temp=$(mktemp --suffix="$extension")
+
+cp "$1" "$ancestor_temp"
+cp "$2" "$current_temp"
+cp "$3" "$other_temp"
+
+fmeworkbench -TITLE-OVERRIDE "[$4] Merge" \
+   -COMPARE-BASE "$ancestor_temp" -COMPARE-BASE-TITLE "Base" \
+   -COMPARE-TITLE1 "Ours" -COMPARE-TITLE2 "Theirs" \
+   -COMPARE "$current_temp" "$other_temp" \
+   -MERGE-OUTPUT "$result_temp"
+
+merge_status=$?
+
+if [ "$merge_status" -eq 0 ]; then
+   cp "$result_temp" "$2"
+   echo "Merge completed successfully."
+else
+   echo "Merge conflict unresolved."
+fi
+
+rm -f "$ancestor_temp" "$current_temp" "$other_temp" "$result_temp"
+
+exit $merge_status

--- a/workspace_merge.sh
+++ b/workspace_merge.sh
@@ -18,6 +18,9 @@ cp "$1" "$ancestor_temp"
 cp "$2" "$current_temp"
 cp "$3" "$other_temp"
 
+# Surpress Qt log messages to avoid adding noise in users workflow
+export QT_LOGGING_RULES="*=false"
+
 fmeworkbench -TITLE-OVERRIDE "[$4] Merge" \
    -COMPARE-BASE "$ancestor_temp" -COMPARE-BASE-TITLE "Base" \
    -COMPARE-TITLE1 "Ours" -COMPARE-TITLE2 "Theirs" \


### PR DESCRIPTION
The main fix is the first commit which allows `workspace_merge.sh` to work in 25.0+ again. Before this, you would get the following when attempting to launch the comparisons:
![image](https://github.com/user-attachments/assets/7677e552-c882-43df-92fb-556071ec200c)
